### PR TITLE
Fixes #69

### DIFF
--- a/src/app/courses/course-list/course-list.component.ts
+++ b/src/app/courses/course-list/course-list.component.ts
@@ -78,5 +78,6 @@ export class CourseListComponent implements OnInit, OnDestroy {
   changeSpecialization(type) {
     this.specialization = type;
     this.store.dispatch(new FilterCourses(this.specialization));
+    this.dataSource.paginator.firstPage();
   }
 }


### PR DESCRIPTION
Set paginator to first page whenever changing specilization. It's better than resetting the paginator, as this could keep the page size user may have changed.